### PR TITLE
Drop original BibTex file

### DIFF
--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
@@ -28,9 +28,12 @@ jobs:
         run: |
           docker run -v `pwd`:/workspace -w /workspace ghcr.io/spherex/spherex-tex:latest sh -c 'make'
 
+      - name: Rename PDF
+        run: mv {{ cookiecutter.handle }}.pdf {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
+
       - name: Upload PDF
         uses: actions/upload-artifact@v2
         with:
           name: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
-          path: {{ cookiecutter.handle }}.pdf
+          path: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
           retention-days: 14

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/Makefile
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/Makefile
@@ -7,7 +7,7 @@ ifneq "$(GITSTATUS)" ""
 	GITDIRTY = -dirty
 endif
 
-$(DOCNAME).pdf: *.tex meta.tex spherex_pipeline_references.bib
+$(DOCNAME).pdf: *.tex meta.tex
 	latexmk -bibtex -xelatex -f $(DOCNAME)
 
 .PHONY: clean


### PR DESCRIPTION
The bibtex file now lives in spherex-tex, so it
should not be a dependency for this make command.