### PR TITLE
Update template workflow to comment on PR with artifact link

### DIFF
--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
@@ -39,3 +39,11 @@ jobs:
           name: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
           path: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
           retention-days: 90
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        if: ${{'{{'}} github.event_name == 'pull_request' {{'}}'}}
+        with:
+          token: ${{'{{'}} secrets.ARTIFACTS_COMMENTING_TOKEN {{'}}'}}
+          event-type: pr-build
+          client-payload: '{"prnumber": "${{'{{'}} github.event.number {{'}}'}}", "checkrunid": "${{'{{'}} github.run_id {{'}}'}}"}'

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
-"on": [push, pull_request]
+"on":
+  pull_request:
 
 jobs:
   tex:

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
@@ -15,8 +15,9 @@ jobs:
           submodules: true
 
       - name: Get SHA
-        uses: benjlevesque/short-sha@v1.2
         id: short-sha
+        run: |
+          echo "::set-output name=sha::$(echo ${{'{{'}} github.event.pull_request.head.sha {{'}}'}} | cut -c 1-7)"
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/ci.yaml
@@ -38,4 +38,4 @@ jobs:
         with:
           name: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
           path: {{ cookiecutter.handle }}-${{'{{'}} steps.short-sha.outputs.sha {{'}}'}}.pdf
-          retention-days: 14
+          retention-days: 90

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/prcomment.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.github/workflows/prcomment.yaml
@@ -1,0 +1,47 @@
+name: Comment on artifacts
+on:
+  repository_dispatch:
+
+jobs:
+  comment:
+    name: Add artifact links to pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo inputs
+        run: |
+          echo ${{'{{'}} github.event.client_payload.prnumber {{'}}'}}
+          echo ${{'{{'}} github.event.client_payload.checkrunid {{'}}'}}
+
+      - name: Get check_suite_id
+        id: getsuiteid
+        run: |
+          URL="https://api.github.com/repos/${{'{{'}} github.repository {{'}}'}}/actions/runs/${{'{{'}} github.event.client_payload.checkrunid {{'}}'}}"
+          check_suite_id=$(curl -s -u admin:${{'{{'}} secrets.GITHUB_TOKEN {{'}}'}} $URL | jq -r '.check_suite_url' | awk -F "/" '{print $NF}')
+          echo $check_suite_id
+          echo "::set-output name=suiteid::$check_suite_id"
+
+      - name: Get artifacts_id
+        id: getartid
+        run: |
+          URL="https://api.github.com/repos/${{'{{'}} github.repository {{'}}'}}/actions/runs/${{'{{'}} github.event.client_payload.checkrunid {{'}}'}}/artifacts"
+          artifacts_id=$(curl -s -u admin:${{'{{'}} secrets.GITHUB_TOKEN {{'}}'}} $URL | jq '.artifacts[].id')
+          echo $artifacts_id
+          echo "::set-output name=artifactid::$artifacts_id"
+
+      - name: Create comment
+        uses: actions/github-script@v4.1.0
+        env:
+          PRNUMBER: ${{'{{'}} github.event.client_payload.prnumber {{'}}'}}
+          SUITEID: ${{'{{'}} steps.getsuiteid.outputs.suiteid {{'}}'}}
+          ARTIFACTID: ${{'{{'}} steps.getartid.outputs.artifactid {{'}}'}}
+        with:
+          script: |
+            const { PRNUMBER, SUITEID, ARTIFACTID } = process.env
+            const { repo: { owner, repo } } = context;
+            const message = `[Download the latest PDF](https://github.com/${owner}/${repo}/suites/${SUITEID}/artifacts/${ARTIFACTID}) (valid for 90 days)`;
+            github.issues.createComment({
+              issue_number: PRNUMBER,
+              owner: owner,
+              repo: repo,
+              body: message
+            });


### PR DESCRIPTION
The purpose of this change is to make it easier to find the PDFs that result from PR builds. Whenever there is a build, a "bot" will reply to the PR with a link to the latest PDF. A team member can click on that and download the associated PDF build artifact.

To implement this change, a new [Organization-wide GitHub secret is required](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization) in the SPHEREx org. The secret should be called `ARTIFACTS_COMMENTING_TOKEN`. The value is a [GitHub Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) that has full `repo` scope. This token is required to trigger the repository dispatch action that actually creates the PR comment.

Then, for each pipeline module document repository, update the `.github/workflows/ci.yaml` file with the new version based on this template. Also add the new workflow, `.github/workflows/comment.yaml`.

Other changes:

- Increased artifact retention from 14 to 90 days. This is the maximum that GitHub allows.
- Updated how the short SHA in the filename is computed so that it reflects the commit that was pushed to GitHub.
- The `ci.yaml` workflow now triggers _only_ for pull requests. This simplifies the logic associated with commenting on PRs.