### PR TITLE
SP-243: Make template README consistent with the template variables (fixup)

### DIFF
--- a/project-management-latex/{{cookiecutter.handle|lower|slugify}}/README.md
+++ b/project-management-latex/{{cookiecutter.handle|lower|slugify}}/README.md
@@ -1,9 +1,9 @@
-# {{ cookiecutter.handle }}: {{ cookiecutter.module_name }}
+# {{ cookiecutter.handle }}: {{ cookiecutter.title }}
 
 
 ## SPHEREx Science Data Center document
 
-This is the repository for the *{{ cookiecutter.module_name }}* Project Management document.
+This is the repository for the *{{ cookiecutter.title }}* Project Management document.
 
 ## Links
 


### PR DESCRIPTION
Caught one more place where "module_name" had to be replaced with "title".