### PR TITLE
Drop the pdf field from lander.yaml templates

### DIFF
--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/lander.yaml
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/lander.yaml
@@ -1,5 +1,4 @@
 source_path: {{ cookiecutter.handle }}.tex
-pdf: {{ cookiecutter.handle }}.pdf
 parser: spherex-pipeline-module
 theme: spherex
 canonical_url: https://spherex-docs.ipac.caltech.edu/{{ cookiecutter.handle|lower|slugify }}/

--- a/project-management-latex/{{cookiecutter.handle|lower|slugify}}/lander.yaml
+++ b/project-management-latex/{{cookiecutter.handle|lower|slugify}}/lander.yaml
@@ -1,5 +1,4 @@
 source_path: {{ cookiecutter.handle }}.tex
-pdf: {{ cookiecutter.handle }}.pdf
 parser: spherex-project-management
 theme: spherex
 canonical_url: https://spherex-docs.ipac.caltech.edu/{{ cookiecutter.handle|lower|slugify }}/


### PR DESCRIPTION
We don't actually use the "pdf" configuration in practice because the reusable workflow
(SPHEREx/spherex-doc-workflows/.github/workflows/build-tex.yaml) renames the PDF with the commit or tag name. This exposes a bug in the new lander where the --pdf command line argument wasn't overriding the lander.yaml settings; this will be fixed, but removing it from the template is also good for long-term simplicity.