### PR TITLE
SP-299: Go back to using the modified OIA/IF document title from the cookiecutter dialog

### DIFF
--- a/oia-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
+++ b/oia-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
@@ -181,3 +181,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# emacs/mg
+*~

--- a/oia-latex/{{cookiecutter.handle|lower|slugify}}/{{cookiecutter.handle}}.tex
+++ b/oia-latex/{{cookiecutter.handle|lower|slugify}}/{{cookiecutter.handle}}.tex
@@ -4,7 +4,7 @@
 \input{meta}
 
 \spherexHandle{ {{- cookiecutter.handle -}} }
-\title{SSDC-- {{- cookiecutter.partner }} Operational Interface Agreement}
+\title{ {{- cookiecutter.title|replace("SSDC-","SSDC--",1) -}} }
 \shortTitle{SSDC-- {{- cookiecutter.partner }} OIA}
 
 \interfacepartner{ {{- cookiecutter.partner -}} }

--- a/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.gitignore
+++ b/pipeline-module/{{cookiecutter.handle|lower|slugify}}/.gitignore
@@ -181,3 +181,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# emacs/mg
+*~

--- a/ssdc-dp-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
+++ b/ssdc-dp-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
@@ -173,9 +173,6 @@ TSWLatexianTemp*
 *.bak
 *.sav
 
-# Emacs/mg
-*~
-
 # Texpad
 .texpadtmp
 
@@ -184,3 +181,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# emacs/mg
+*~

--- a/ssdc-op-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
+++ b/ssdc-op-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
@@ -173,9 +173,6 @@ TSWLatexianTemp*
 *.bak
 *.sav
 
-# Emacs/mg
-*~
-
 # Texpad
 .texpadtmp
 
@@ -184,3 +181,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# emacs/mg
+*~

--- a/ssdc-tn-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
+++ b/ssdc-tn-latex/{{cookiecutter.handle|lower|slugify}}/.gitignore
@@ -173,9 +173,6 @@ TSWLatexianTemp*
 *.bak
 *.sav
 
-# Emacs/mg
-*~
-
 # Texpad
 .texpadtmp
 
@@ -184,3 +181,6 @@ TSWLatexianTemp*
 
 # KBibTeX
 *~[0-9]*
+
+# emacs/mg
+*~


### PR DESCRIPTION
Address the reason for the previous change by transforming "-" into "--" in the LaTeX version of the title.

Fixes a residual issue in the OIA / SSDC-IF template and allows closing SP-299.
Also makes all document templates' `.gitignore` files the same (-IF and -MS were missing emacs backups).